### PR TITLE
fix: virtual reference

### DIFF
--- a/src/linkers/pnp.ts
+++ b/src/linkers/pnp.ts
@@ -22,7 +22,7 @@ export const getPackagePath = async (project: Project, pkg: Package): Promise<Po
   const locator = structUtils.convertPackageToLocator(pkg)
   const pnpLocator = {
     name: structUtils.stringifyIdent(locator),
-    reference: locator.reference
+    reference: locator.reference.startsWith('virtual:') ? locator.reference.split('#')[1] : locator.reference
   }
 
   const packageInformation = pnpApi.getPackageInformation(pnpLocator)


### PR DESCRIPTION
Thank you for your hard work.

While using this library, it was observed that references marked as virtual do not function properly and are being skipped. Therefore, I will modify it so that virtual references operate correctly.


https://yarnpkg.com/advanced/pnp-spec#basic-concepts
```js
// locator.reference output

virtual:hash#npm:version::_archiveUrl=~~ // this skip
npm:version::_archiveUrl=~~
npm:version::_archiveUrl=~~
npm:version::_archiveUrl=~~
```